### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 var express = require('express');
-var session = require('express-session')
+var session = require('express-session');
 var engine = require('ejs-locals');
 var path = require('path');
 var favicon = require('serve-favicon');


### PR DESCRIPTION
To fix this issue, add a semicolon at the end of any variable assignment or expression statement that currently omits it, specifically at the end of line 2 (`var session = require('express-session')`). This should be done without adding any extra functionality or changing how the code runs, but will ensure code style and maintainability are improved, and future errors due to ASI are less likely. Make the change in the file `app.js`, at line 2, and verify that other similar statements (like lines 10, 26, 91) are handled similarly for consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._