### PR TITLE
Fix for Semicolon insertion

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,7 +88,7 @@ app.use(function(err, req, res, next) {
 /*
  * Create database
  */
-logger4js.info("Building database")
+logger4js.info("Building database");
 // logger.info(("Building database");
 
 init_db();


### PR DESCRIPTION
To fix the problem, we should add an explicit semicolon at the end of the statement on line 91: `logger4js.info("Building database")`. This change ensures consistency with the surrounding code, adheres to common JavaScript best practices, and eliminates reliance on ASI. Only a single character needs to be added at the end of line 91 in `app.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._